### PR TITLE
Fix Electron MCP server: real tools + stdio-safe logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,225 +1,117 @@
-# 🚀 Electron Debug MCP Server
+# Electron Debug MCP Server
 
-[![TypeScript](https://img.shields.io/badge/TypeScript-007ACC?style=for-the-badge&logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
-[![Electron](https://img.shields.io/badge/Electron-47848F?style=for-the-badge&logo=electron&logoColor=white)](https://www.electronjs.org/)
-[![Chrome DevTools Protocol](https://img.shields.io/badge/CDP-4285F4?style=for-the-badge&logo=google-chrome&logoColor=white)](https://chromedevtools.github.io/devtools-protocol/)
-[![Model Context Protocol](https://img.shields.io/badge/MCP-6236FF?style=for-the-badge&logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIiBzdHJva2U9IiNmZmZmZmYiIHN0cm9rZS13aWR0aD0iMiIgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIiBzdHJva2UtbGluZWpvaW49InJvdW5kIj48cGF0aCBkPSJNMTggMThhMSAxIDAgMCAxLTEgMUg3YTEgMSAwIDAgMS0xLTFWNmExIDEgMCAwIDEgMS0xaDEwYTEgMSAwIDAgMSAxIDF2MTJ6Ij48L3BhdGg+PHBhdGggZD0iTTEyIDZ2MTIiPjwvcGF0aD48cGF0aCBkPSJNNiA5aDEyIj48L3BhdGg+PHBhdGggZD0iTTYgMTVoMTIiPjwvcGF0aD48L3N2Zz4=&logoColor=white)](https://modelcontextprotocol.ai/)
+MCP server for launching and debugging Electron apps through the Chrome DevTools Protocol.
 
-A powerful Model Context Protocol (MCP) server for debugging Electron applications with deep Chrome DevTools Protocol integration.
+## What it does
 
-## 📋 Table of Contents
+- **Tools** start/stop Electron apps, evaluate JS, reload pages, pause/resume, and run arbitrary CDP methods
+- **Resources** expose read-only process info, logs, and CDP targets
+- Speaks MCP over **stdio** (safe for Cursor / Claude Desktop)
 
-- [Overview](#-overview)
-- [Features](#-features)
-- [Installation](#-installation)
-- [Usage](#-usage)
-- [Resource Endpoints](#-resource-endpoints)
-- [Chrome DevTools Protocol Integration](#-chrome-devtools-protocol-integration)
-- [Examples](#-examples)
-- [Development](#-development)
-- [Contributing](#-contributing)
-- [License](#-license)
-
-## 🔍 Overview
-
-Electron Debug MCP Server provides a bridge between the Model Context Protocol (MCP) and Electron applications, enabling advanced debugging capabilities through a standardized API. It allows you to start, monitor, debug, and control Electron applications programmatically, with deep integration with Chrome DevTools Protocol for advanced debugging features.
-
-## ✨ Features
-
-### 🔄 Core Functionality
-
-- **Process Management**
-  - 🚀 Start Electron applications with debugging enabled
-  - 🛑 Stop running Electron processes
-  - 📋 List all active Electron processes
-  - 📊 Monitor process status and logs
-
-### 🔍 Debugging Capabilities
-
-- **Chrome DevTools Protocol Integration**
-  - 🎯 Discover and connect to debugging targets
-  - 🧩 Execute CDP commands across domains
-  - 📝 Evaluate JavaScript in the context of pages
-  - 🔄 Reload pages or entire applications
-  - ⏯️ Pause and resume JavaScript execution
-
-### 📡 Resource Access
-
-- **Structured Resource Endpoints**
-  - 📊 Overview of all running Electron processes
-  - 📝 Detailed debug information for specific processes
-  - 📜 Access to process logs
-  - 🎯 List of available debugging targets
-  - 🔍 Direct CDP access for specific targets
-
-## 📥 Installation
+## Setup
 
 ```bash
-# Clone the repository
-git clone https://github.com/yourusername/electron-mcp-server.git
-
-# Navigate to the project directory
-cd electron-mcp-server
-
-# Install dependencies
+cd D:\GH\electron-mcp-server
 npm install
-
-# Build the project
 npm run build
 ```
 
-## 🚀 Usage
+## Cursor config
 
-### Starting the Server
+Add to your MCP settings (path adjusted to your clone):
 
-```bash
-npm run start
+```json
+{
+  "mcpServers": {
+    "electron-debug": {
+      "command": "node",
+      "args": ["D:/GH/electron-mcp-server/build/index.js"]
+    }
+  }
+}
 ```
 
-This will start the MCP server using stdio for communication.
+Restart Cursor after saving.
 
-### Connecting to the Server
+## Tools
 
-The MCP server uses stdio for communication, so clients need to connect using the Model Context Protocol. You can:
+| Tool | Purpose |
+|------|---------|
+| `start_app` | Start an Electron app with `--remote-debugging-port` |
+| `stop_app` | Stop a managed process |
+| `list_apps` | List managed processes |
+| `get_logs` | Read captured stdout/stderr |
+| `list_targets` | List CDP targets |
+| `evaluate` | `Runtime.evaluate` in a page/renderer |
+| `reload` | `Page.reload` |
+| `pause` / `resume` | `Debugger.pause` / `Debugger.resume` |
+| `cdp_command` | Run any `Domain.method` CDP call |
 
-- Use an MCP client library
-- Connect directly via stdin/stdout
-- Use a tool that supports MCP
+### Examples
 
-## 📡 Resource Endpoints
+Start an app:
 
-The server exposes the following resource endpoints:
-
-| Resource | Description |
-|----------|-------------|
-| `electron://info` | Overview of all running Electron processes |
-| `electron://process/{id}` | Detailed debug info for a specific process |
-| `electron://logs/{id}` | Access to logs for a specific process |
-| `electron://targets` | List of all available debug targets |
-| `electron://cdp/{processId}/{targetId}` | CDP access for a specific target |
-| `electron://operation/{operation}` | Operations to control Electron apps |
-
-### Available Operations
-
-| Operation | Description |
-|-----------|-------------|
-| `start` | Start an Electron application |
-| `stop` | Stop a running Electron process |
-| `list` | List all running Electron processes |
-| `reload` | Reload a specific page or application |
-| `evaluate` | Execute JavaScript in a page context |
-| `pause` | Pause JavaScript execution |
-| `resume` | Resume JavaScript execution |
-
-## 🔍 Chrome DevTools Protocol Integration
-
-The server integrates with Chrome DevTools Protocol to provide deep debugging capabilities:
-
-### Listing Available Targets
-
-```
-GET electron://targets
+```json
+{
+  "appPath": "D:/path/to/your/electron-app",
+  "debugPort": 9222
+}
 ```
 
-Returns all available debugging targets across all running Electron processes.
+Evaluate in the first page target:
 
-### Inspecting a Specific Target
-
-```
-GET electron://cdp/{processId}/{targetId}
-```
-
-Provides information about the target and available CDP domains.
-
-### Executing CDP Commands
-
-```
-GET electron://cdp/{processId}/{targetId}/{domain}/{command}
+```json
+{
+  "processId": "electron-1710000000000",
+  "expression": "document.title"
+}
 ```
 
-Examples:
-- `electron://cdp/electron-123456/page-1/Page/reload` - Reload the page
-- `electron://cdp/electron-123456/page-1/Runtime/evaluate` - Evaluate JavaScript
-- `electron://cdp/electron-123456/page-1/Debugger/pause` - Pause execution
+Raw CDP:
 
-## 📝 Examples
-
-### Starting an Electron App
-
-```javascript
-// Example request (using an MCP client)
-const response = await mcpClient.readResource({
-  uri: "electron://operation/start",
-  content: JSON.stringify({
-    appPath: "C:\\path\\to\\your\\electron\\app",
-    debugPort: 9222  // Optional debugging port
-  })
-});
+```json
+{
+  "processId": "electron-1710000000000",
+  "method": "Page.navigate",
+  "params": { "url": "https://example.com" }
+}
 ```
 
-### Getting Debug Information
+## Resources (read-only)
 
-```javascript
-// Get detailed info about a specific app
-const processId = "electron-1234567890";
-const infoResponse = await mcpClient.readResource({
-  uri: `electron://process/${processId}`
-});
-```
+| URI | Description |
+|-----|-------------|
+| `electron://info` | Managed process overview |
+| `electron://targets` | All CDP targets |
+| `electron://process/{id}` | Process debug details |
+| `electron://logs/{id}` | Process logs |
+| `electron://cdp/{processId}/{targetId}` | Target metadata |
 
-### Executing JavaScript in a Page
-
-```javascript
-// Execute JavaScript in a page
-const evalResponse = await mcpClient.readResource({
-  uri: `electron://cdp/electron-123456/page-1/Runtime/evaluate`,
-  content: JSON.stringify({
-    expression: "document.title",
-    returnByValue: true
-  })
-});
-```
-
-## 🛠️ Development
-
-### Project Structure
-
-```
-electron-mcp-server/
-├── src/
-│   ├── index.ts         # Main server implementation
-│   └── types/           # TypeScript type definitions
-├── build/               # Compiled JavaScript output
-├── package.json         # Project dependencies and scripts
-└── tsconfig.json        # TypeScript configuration
-```
-
-### Building the Project
+## Development
 
 ```bash
 npm run build
+npm start
+npm run typecheck
 ```
 
-### Running in Development Mode
+Project layout:
 
-```bash
-npm run dev
+```
+src/
+  index.ts              # MCP tools + resources
+  process-manager.ts    # Electron process + CDP helpers
+  log.ts                # stderr-only logging
+  types/                # ambient typings
 ```
 
-## 🤝 Contributing
+## Notes
 
-Contributions are welcome! Please feel free to submit a Pull Request.
+- Logs go to **stderr** so stdio JSON-RPC on stdout stays clean
+- `start_app` waits for the debug port before returning
+- Targets default to the first `page` target when `targetId` is omitted
+- This server manages processes it starts; it does not attach to arbitrary already-running Electron apps yet
 
-1. Fork the repository
-2. Create your feature branch (`git checkout -b feature/amazing-feature`)
-3. Commit your changes (`git commit -m 'Add some amazing feature'`)
-4. Push to the branch (`git push origin feature/amazing-feature`)
-5. Open a Pull Request
+## License
 
-## 📄 License
-
-This project is licensed under the ISC License - see the LICENSE file for details.
-
----
-
-Built with ❤️ using TypeScript, Electron, and Chrome DevTools Protocol.
+ISC

--- a/README.md
+++ b/README.md
@@ -93,7 +93,10 @@ Raw CDP:
 npm run build
 npm start
 npm run typecheck
+npm test
 ```
+
+`npm test` builds the server, then runs `test/mcp-smoke.mjs` against `fixtures/minimal-electron-app` (start → list targets → evaluate → stop).
 
 Project layout:
 
@@ -103,6 +106,10 @@ src/
   process-manager.ts    # Electron process + CDP helpers
   log.ts                # stderr-only logging
   types/                # ambient typings
+fixtures/
+  minimal-electron-app/ # Tiny Electron app used by smoke tests
+test/
+  mcp-smoke.mjs         # End-to-end MCP stdio smoke test
 ```
 
 ## Notes

--- a/fixtures/minimal-electron-app/index.html
+++ b/fixtures/minimal-electron-app/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Minimal Electron Fixture</title>
+  </head>
+  <body>
+    <h1 id="heading">Hello from fixture</h1>
+    <p id="status">ready</p>
+    <script>
+      window.__FIXTURE__ = {
+        name: "minimal-electron-app",
+        version: 1,
+      };
+    </script>
+  </body>
+</html>

--- a/fixtures/minimal-electron-app/main.js
+++ b/fixtures/minimal-electron-app/main.js
@@ -1,0 +1,31 @@
+const { app, BrowserWindow } = require("electron");
+const path = require("path");
+
+// Helpful in CI/containers; CLI --no-sandbox is still preferred.
+app.commandLine.appendSwitch("no-sandbox");
+app.commandLine.appendSwitch("disable-gpu");
+
+let mainWindow;
+
+app.whenReady().then(() => {
+  mainWindow = new BrowserWindow({
+    width: 640,
+    height: 480,
+    show: false,
+    webPreferences: {
+      nodeIntegration: false,
+      contextIsolation: true,
+    },
+  });
+
+  mainWindow.loadFile(path.join(__dirname, "index.html"));
+
+  // Keep running until the MCP server stops us.
+  console.log("minimal-electron-app ready");
+});
+
+app.on("window-all-closed", () => {
+  if (process.platform !== "darwin") {
+    app.quit();
+  }
+});

--- a/fixtures/minimal-electron-app/package.json
+++ b/fixtures/minimal-electron-app/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "minimal-electron-app",
+  "version": "1.0.0",
+  "private": true,
+  "main": "main.js"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,11 +12,17 @@
         "@modelcontextprotocol/sdk": "^1.1.0",
         "chrome-remote-interface": "^0.33.0",
         "electron": "^29.1.0",
-        "ws": "^8.16.0"
+        "zod": "^3.24.2"
+      },
+      "bin": {
+        "electron-debug-mcp": "build/index.js"
       },
       "devDependencies": {
         "@types/node": "^22.10.5",
         "typescript": "^5.7.2"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@electron/get": {
@@ -1745,27 +1751,6 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
-    },
-    "node_modules/ws": {
-      "version": "8.18.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.1.tgz",
-      "integrity": "sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
     },
     "node_modules/yauzl": {
       "version": "2.10.0",

--- a/package.json
+++ b/package.json
@@ -2,24 +2,36 @@
   "name": "electron-debug-mcp",
   "version": "1.0.0",
   "type": "module",
+  "bin": {
+    "electron-debug-mcp": "./build/index.js"
+  },
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && node --input-type=module -e \"import fs from 'fs'; fs.chmodSync('build/index.js', 0o755)\"",
     "start": "node build/index.js",
     "dev": "tsc && node build/index.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "typecheck": "tsc --noEmit"
   },
-  "keywords": ["electron", "debug", "mcp", "model-context-protocol"],
+  "keywords": [
+    "electron",
+    "debug",
+    "mcp",
+    "model-context-protocol",
+    "chrome-devtools-protocol"
+  ],
   "author": "",
   "license": "ISC",
-  "description": "An MCP server for Electron debugging",
+  "description": "MCP server for launching and debugging Electron apps via Chrome DevTools Protocol",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.1.0",
-    "electron": "^29.1.0",
     "chrome-remote-interface": "^0.33.0",
-    "ws": "^8.16.0"
+    "electron": "^29.1.0",
+    "zod": "^3.24.2"
   },
   "devDependencies": {
     "@types/node": "^22.10.5",
     "typescript": "^5.7.2"
+  },
+  "engines": {
+    "node": ">=18"
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "build": "tsc && node --input-type=module -e \"import fs from 'fs'; fs.chmodSync('build/index.js', 0o755)\"",
     "start": "node build/index.js",
     "dev": "tsc && node build/index.js",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "npm run build && node test/mcp-smoke.mjs",
+    "test:smoke": "node test/mcp-smoke.mjs"
   },
   "keywords": [
     "electron",

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,10 +61,16 @@ server.tool(
       .max(65535)
       .optional()
       .describe("Optional Chrome DevTools debugging port (default: random 9222-9999)"),
+    extraArgs: z
+      .array(z.string())
+      .optional()
+      .describe(
+        'Optional extra Electron CLI args (e.g. ["--no-sandbox"] for CI/containers)'
+      ),
   },
-  async ({ appPath, debugPort }) => {
+  async ({ appPath, debugPort, extraArgs }) => {
     try {
-      const proc = await startElectronApp(appPath, debugPort);
+      const proc = await startElectronApp(appPath, debugPort, extraArgs ?? []);
       return textResult({
         id: proc.id,
         name: proc.name,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,684 +1,569 @@
-import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+#!/usr/bin/env node
+import { McpServer, ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { z } from "zod";
+import { log } from "./log.js";
 import {
-  ListResourcesRequestSchema,
-  ReadResourceRequestSchema
-} from "@modelcontextprotocol/sdk/types.js";
-import { spawn, ChildProcess } from 'child_process';
-import * as fs from 'fs';
-import * as path from 'path';
-import * as os from 'os';
-// @ts-ignore
-import CDP from 'chrome-remote-interface';
-import * as http from 'http';
-import * as net from 'net';
+  connectToCDPTarget,
+  executeCDPCommand,
+  getAllProcesses,
+  getElectronDebugInfo,
+  getProcess,
+  listProcesses,
+  pickPageTarget,
+  startElectronApp,
+  stopElectronApp,
+  updateCDPTargets,
+} from "./process-manager.js";
 
-// Define custom resource URIs for Electron debugging
-const ELECTRON_RESOURCES = {
-  INFO: "electron://info",
-  PROCESS: "electron://process/",
-  LOGS: "electron://logs/",
-  OPERATION: "electron://operation/",
-  CDP: "electron://cdp/",
-  TARGETS: "electron://targets"
-};
-
-// Define operation types for Electron debugging
-const ELECTRON_OPERATIONS = {
-  START: "start",
-  STOP: "stop",
-  LIST: "list",
-  RELOAD: "reload",
-  PAUSE: "pause",
-  RESUME: "resume",
-  EVALUATE: "evaluate"
-};
-
-// Type definitions for Electron processes and debugging info
-interface ElectronProcess {
-  id: string;
-  process: ChildProcess;
-  name: string;
-  status: 'running' | 'stopped' | 'crashed';
-  pid?: number;
-  debugPort?: number;
-  startTime: Date;
-  logs: string[];
-  appPath: string;
-  cdpClient?: any; // Chrome DevTools Protocol client
-  targets?: CDPTarget[]; // Available debugging targets
-  lastTargetUpdate?: Date; // When targets were last updated
-}
-
-interface ElectronDebugInfo {
-  webContents: ElectronWebContentsInfo[];
-  processes: {
-    main: ProcessInfo;
-    renderers: ProcessInfo[];
-  };
-}
-
-interface ElectronWebContentsInfo {
-  id: number;
-  url: string;
-  title: string;
-  debuggable: boolean;
-  debugPort?: number;
-  targetId?: string; // CDP target ID
-}
-
-interface CDPTarget {
-  id: string;
-  type: string;
-  title: string;
-  url: string;
-  webSocketDebuggerUrl?: string;
-  devtoolsFrontendUrl?: string;
-}
-
-interface ProcessInfo {
-  pid: number;
-  cpuUsage: number;
-  memoryUsage: number;
-  status: string;
-}
-
-// Store active Electron processes
-const electronProcesses: Map<string, ElectronProcess> = new Map();
-
-// Helper functions for Electron debugging
-function getElectronExecutablePath(): string {
-  // Try to find electron in common locations
-  const possiblePaths = [
-    // Check if electron is installed globally
-    path.join(os.homedir(), 'AppData', 'Roaming', 'npm', 'electron.cmd'),
-    // Check in node_modules of the current project
-    path.resolve(process.cwd(), 'node_modules', '.bin', 'electron.cmd')
-  ];
-
-  for (const electronPath of possiblePaths) {
-    if (fs.existsSync(electronPath)) {
-      return electronPath;
-    }
-  }
-
-  // Default to expecting electron to be in PATH
-  return 'electron';
-}
-
-async function startElectronApp(appPath: string, debugPort?: number): Promise<ElectronProcess> {
-  const id = `electron-${Date.now()}`;
-  const args = [appPath];
-  
-  // If no debug port specified, choose a random one between 9222 and 9999
-  if (!debugPort) {
-    debugPort = Math.floor(Math.random() * (9999 - 9222 + 1)) + 9222;
-  }
-  
-  // Add debugging flags
-  args.unshift(`--remote-debugging-port=${debugPort}`);
-  args.unshift('--enable-logging');
-  
-  const electronPath = getElectronExecutablePath();
-  const electronProc = spawn(electronPath, args, {
-    stdio: ['pipe', 'pipe', 'pipe'],
-    env: { ...process.env, ELECTRON_ENABLE_LOGGING: '1' }
-  });
-  
-  const electronProcess: ElectronProcess = {
-    id,
-    process: electronProc,
-    name: path.basename(appPath),
-    status: 'running',
-    pid: electronProc.pid,
-    debugPort,
-    startTime: new Date(),
-    logs: [],
-    appPath
-  };
-  
-  // Capture stdout and stderr
-  electronProc.stdout.on('data', (data: Buffer) => {
-    const log = data.toString();
-    electronProcess.logs.push(log);
-    // Log to console instead of sending notifications
-    console.log(`[Electron ${id}] ${log}`);
-  });
-  
-  electronProc.stderr.on('data', (data: Buffer) => {
-    const log = data.toString();
-    electronProcess.logs.push(log);
-    // Log to console instead of sending notifications
-    console.error(`[Electron ${id}] ${log}`);
-  });
-  
-  // Handle process exit
-  electronProc.on('exit', (code: number | null) => {
-    electronProcess.status = code === 0 ? 'stopped' : 'crashed';
-    console.info(`[Electron ${id}] Process exited with code ${code}`);
-    
-    // Clean up CDP client if it exists
-    if (electronProcess.cdpClient) {
-      try {
-        electronProcess.cdpClient.close();
-      } catch (err) {
-        console.error(`[Electron ${id}] Error closing CDP client:`, err);
-      }
-      electronProcess.cdpClient = undefined;
-    }
-  });
-  
-  electronProcesses.set(id, electronProcess);
-  
-  // Wait a moment for the app to start and initialize the debugging port
-  await new Promise(resolve => setTimeout(resolve, 1000));
-  
-  // Try to connect to CDP and get available targets
-  try {
-    await updateCDPTargets(electronProcess);
-  } catch (err) {
-    console.warn(`[Electron ${id}] Could not connect to CDP initially:`, err);
-  }
-  
-  return electronProcess;
-}
-
-function stopElectronApp(id: string): boolean {
-  const electronProcess = electronProcesses.get(id);
-  if (!electronProcess) {
-    return false;
-  }
-  
-  // Close CDP client if it exists
-  if (electronProcess.cdpClient) {
-    try {
-      electronProcess.cdpClient.close();
-    } catch (err) {
-      console.error(`[Electron ${id}] Error closing CDP client:`, err);
-    }
-    electronProcess.cdpClient = undefined;
-  }
-  
-  electronProcess.process.kill();
-  electronProcess.status = 'stopped';
-  return true;
-}
-
-async function getElectronDebugInfo(id: string): Promise<ElectronDebugInfo | null> {
-  const electronProcess = electronProcesses.get(id);
-  if (!electronProcess || electronProcess.status !== 'running') {
-    return null;
-  }
-  
-  // Update CDP targets to get the latest information
-  try {
-    await updateCDPTargets(electronProcess);
-  } catch (err) {
-    console.warn(`[Electron ${id}] Could not update CDP targets:`, err);
-  }
-  
-  // Convert CDP targets to WebContents info
-  const webContents: ElectronWebContentsInfo[] = electronProcess.targets?.map((target, index) => ({
-    id: index + 1,
-    url: target.url,
-    title: target.title,
-    debuggable: !!target.webSocketDebuggerUrl,
-    debugPort: electronProcess.debugPort,
-    targetId: target.id
-  })) || [
-    {
-      id: 1,
-      url: 'file://' + electronProcess.appPath,
-      title: electronProcess.name,
-      debuggable: true,
-      debugPort: electronProcess.debugPort
-    }
-  ];
-  
+function textResult(data: unknown, isError = false) {
   return {
-    webContents,
-    processes: {
-      main: {
-        pid: electronProcess.pid || 0,
-        cpuUsage: Math.random() * 10, // We could get real data with CDP
-        memoryUsage: Math.random() * 100 * 1024 * 1024,
-        status: 'running'
+    content: [
+      {
+        type: "text" as const,
+        text:
+          typeof data === "string" ? data : JSON.stringify(data, null, 2),
       },
-      renderers: [
-        {
-          pid: (electronProcess.pid || 0) + 1,
-          cpuUsage: Math.random() * 5,
-          memoryUsage: Math.random() * 50 * 1024 * 1024,
-          status: 'running'
-        }
-      ]
-    }
+    ],
+    isError,
   };
 }
 
-// Add CDP-related functions
-
-/**
- * Updates the CDP targets for an Electron process
- */
-async function updateCDPTargets(electronProcess: ElectronProcess): Promise<CDPTarget[]> {
-  if (!electronProcess.debugPort) {
-    throw new Error('No debug port available for this Electron process');
+function requireRunningProcess(processId: string) {
+  const proc = getProcess(processId);
+  if (!proc) {
+    throw new Error(`Process not found: ${processId}`);
   }
-  
-  try {
-    // Get the list of available targets from the Chrome DevTools Protocol
-    const response = await fetch(`http://localhost:${electronProcess.debugPort}/json/list`);
-    if (!response.ok) {
-      throw new Error(`Failed to get targets: ${response.statusText}`);
-    }
-    
-    const targets = await response.json() as CDPTarget[];
-    electronProcess.targets = targets;
-    electronProcess.lastTargetUpdate = new Date();
-    return targets;
-  } catch (error) {
-    console.error(`Error getting CDP targets for process ${electronProcess.id}:`, error);
-    throw error;
+  if (proc.status !== "running") {
+    throw new Error(`Process ${processId} is ${proc.status}`);
   }
+  return proc;
 }
 
-/**
- * Connects to a specific CDP target
- */
-async function connectToCDPTarget(electronProcess: ElectronProcess, targetId: string): Promise<any> {
-  if (!electronProcess.debugPort) {
-    throw new Error('No debug port available for this Electron process');
-  }
-  
-  try {
-    // Make sure we have the latest targets
-    if (!electronProcess.targets || !electronProcess.lastTargetUpdate || 
-        (new Date().getTime() - electronProcess.lastTargetUpdate.getTime() > 5000)) {
-      await updateCDPTargets(electronProcess);
-    }
-    
-    // Find the target
-    const target = electronProcess.targets?.find(t => t.id === targetId);
-    if (!target) {
-      throw new Error(`Target ${targetId} not found`);
-    }
-    
-    // Connect to the target using CDP
-    const client = await CDP({
-      target: targetId,
-      port: electronProcess.debugPort
-    } as any);
-    
-    // Store the client for later use
-    electronProcess.cdpClient = client;
-    return client;
-  } catch (error) {
-    console.error(`Error connecting to CDP target ${targetId}:`, error);
-    throw error;
-  }
-}
+const server = new McpServer({
+  name: "electron-debug-mcp",
+  version: "1.0.0",
+});
 
-/**
- * Executes a CDP command on a target
- */
-async function executeCDPCommand(electronProcess: ElectronProcess, targetId: string, domain: string, command: string, params: any = {}): Promise<any> {
-  let client;
-  
-  try {
-    // Get or create a CDP client
-    if (electronProcess.cdpClient) {
-      client = electronProcess.cdpClient;
-    } else {
-      client = await connectToCDPTarget(electronProcess, targetId);
-    }
-    
-    // Execute the command
-    return await client.send(`${domain}.${command}`, params);
-  } catch (error) {
-    console.error(`Error executing CDP command ${domain}.${command}:`, error);
-    throw error;
-  }
-}
+// --- Tools (mutations / actions) ---
 
-// Initialize server with resource capabilities
-const server = new Server(
+server.tool(
+  "start_app",
+  "Start an Electron application with remote debugging enabled",
   {
-    name: "electron-debug-mcp",
-    version: "1.0.0",
+    appPath: z
+      .string()
+      .describe("Path to the Electron app (directory or main script)"),
+    debugPort: z
+      .number()
+      .int()
+      .min(1024)
+      .max(65535)
+      .optional()
+      .describe("Optional Chrome DevTools debugging port (default: random 9222-9999)"),
   },
-  {
-    capabilities: {
-      resources: {}, // Enable resources
-    },
+  async ({ appPath, debugPort }) => {
+    try {
+      const proc = await startElectronApp(appPath, debugPort);
+      return textResult({
+        id: proc.id,
+        name: proc.name,
+        status: proc.status,
+        pid: proc.pid,
+        debugPort: proc.debugPort,
+        appPath: proc.appPath,
+        targets: proc.targets ?? [],
+      });
+    } catch (err) {
+      return textResult(
+        err instanceof Error ? err.message : String(err),
+        true
+      );
+    }
   }
 );
 
-// List available resources when clients request them
-server.setRequestHandler(ListResourcesRequestSchema, async () => {
-  // Create a list of resources including all active Electron processes and operations
-  const resources = [
-    {
-      uri: ELECTRON_RESOURCES.INFO,
-      name: "Electron Debugging Info",
-      description: "Information about the Electron debugging capabilities",
-      mimeType: "application/json",
-    },
-    {
-      uri: `${ELECTRON_RESOURCES.OPERATION}${ELECTRON_OPERATIONS.START}`,
-      name: "Start Electron App",
-      description: "Start an Electron application for debugging",
-      mimeType: "application/json",
-    },
-    {
-      uri: `${ELECTRON_RESOURCES.OPERATION}${ELECTRON_OPERATIONS.STOP}`,
-      name: "Stop Electron App",
-      description: "Stop a running Electron application",
-      mimeType: "application/json",
-    },
-    {
-      uri: `${ELECTRON_RESOURCES.OPERATION}${ELECTRON_OPERATIONS.LIST}`,
-      name: "List Electron Apps",
-      description: "List all running Electron applications",
-      mimeType: "application/json",
-    },
-    {
-      uri: `${ELECTRON_RESOURCES.OPERATION}${ELECTRON_OPERATIONS.RELOAD}`,
-      name: "Reload Electron App",
-      description: "Reload a running Electron application",
-      mimeType: "application/json",
-    },
-    {
-      uri: `${ELECTRON_RESOURCES.OPERATION}${ELECTRON_OPERATIONS.EVALUATE}`,
-      name: "Evaluate JavaScript",
-      description: "Evaluate JavaScript in a running Electron application",
-      mimeType: "application/json",
-    },
-    {
-      uri: ELECTRON_RESOURCES.TARGETS,
-      name: "Electron Debug Targets",
-      description: "List all available debug targets across Electron processes",
-      mimeType: "application/json",
-    }
-  ];
-  
-  // Add resources for each active Electron process
-  for (const [id, process] of electronProcesses.entries()) {
-    resources.push({
-      uri: `${ELECTRON_RESOURCES.PROCESS}${id}`,
-      name: `Electron Process: ${process.name}`,
-      description: `Debug information for Electron process ${process.name}`,
-      mimeType: "application/json",
-    });
-    
-    resources.push({
-      uri: `${ELECTRON_RESOURCES.LOGS}${id}`,
-      name: `Electron Logs: ${process.name}`,
-      description: `Logs for Electron process ${process.name}`,
-      mimeType: "text/plain",
-    });
-    
-    // Add CDP resources for each target in the process
-    if (process.targets && process.targets.length > 0) {
-      for (const target of process.targets) {
-        resources.push({
-          uri: `${ELECTRON_RESOURCES.CDP}${id}/${target.id}`,
-          name: `CDP: ${target.title || target.url}`,
-          description: `Chrome DevTools Protocol access for target ${target.id}`,
-          mimeType: "application/json",
-        });
+server.tool(
+  "stop_app",
+  "Stop a running Electron application started by this server",
+  {
+    processId: z.string().describe("Process id returned by start_app"),
+  },
+  async ({ processId }) => {
+    try {
+      const stopped = await stopElectronApp(processId);
+      if (!stopped) {
+        return textResult(`Process not found: ${processId}`, true);
       }
+      return textResult({ processId, status: "stopped" });
+    } catch (err) {
+      return textResult(
+        err instanceof Error ? err.message : String(err),
+        true
+      );
     }
   }
-  
-  return { resources };
-});
+);
 
-// Handle resource read requests
-server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
-  const { uri } = request.params;
-  
-  // Handle targets listing resource
-  if (uri === ELECTRON_RESOURCES.TARGETS) {
-    // Collect all targets from all processes
-    const allTargets: Array<{processId: string, target: CDPTarget}> = [];
-    
-    for (const [id, process] of electronProcesses.entries()) {
-      // Update targets if needed
-      if (process.status === 'running' && process.debugPort) {
+server.tool(
+  "list_apps",
+  "List Electron applications managed by this server",
+  async () => textResult({ processes: listProcesses() })
+);
+
+server.tool(
+  "get_logs",
+  "Get captured stdout/stderr logs for a managed Electron process",
+  {
+    processId: z.string().describe("Process id returned by start_app"),
+    tail: z
+      .number()
+      .int()
+      .positive()
+      .optional()
+      .describe("Optional number of trailing log chunks to return"),
+  },
+  async ({ processId, tail }) => {
+    const proc = getProcess(processId);
+    if (!proc) {
+      return textResult(`Process not found: ${processId}`, true);
+    }
+    const logs = tail ? proc.logs.slice(-tail) : proc.logs;
+    return textResult({
+      processId,
+      status: proc.status,
+      logs: logs.join(""),
+    });
+  }
+);
+
+server.tool(
+  "list_targets",
+  "List Chrome DevTools Protocol targets for a process (or all processes)",
+  {
+    processId: z
+      .string()
+      .optional()
+      .describe("Optional process id; omit to list targets for all running apps"),
+  },
+  async ({ processId }) => {
+    try {
+      const allTargets: Array<{
+        processId: string;
+        target: unknown;
+      }> = [];
+
+      const entries = processId
+        ? ([[processId, requireRunningProcess(processId)]] as const)
+        : Array.from(getAllProcesses().entries());
+
+      for (const [id, proc] of entries) {
+        if (proc.status !== "running" || !proc.debugPort) {
+          continue;
+        }
         try {
-          await updateCDPTargets(process);
-          if (process.targets) {
-            for (const target of process.targets) {
-              allTargets.push({
-                processId: id,
-                target
-              });
-            }
+          await updateCDPTargets(proc);
+          for (const target of proc.targets ?? []) {
+            allTargets.push({ processId: id, target });
           }
         } catch (err) {
-          console.warn(`Could not update targets for process ${id}:`, err);
+          log.warn(`Could not update targets for ${id}:`, err);
         }
       }
+
+      return textResult({ targets: allTargets });
+    } catch (err) {
+      return textResult(
+        err instanceof Error ? err.message : String(err),
+        true
+      );
     }
-    
+  }
+);
+
+server.tool(
+  "evaluate",
+  "Evaluate JavaScript in an Electron page/renderer via CDP Runtime.evaluate",
+  {
+    processId: z.string().describe("Process id returned by start_app"),
+    expression: z.string().describe("JavaScript expression to evaluate"),
+    targetId: z
+      .string()
+      .optional()
+      .describe("Optional CDP target id; defaults to the first page target"),
+    returnByValue: z
+      .boolean()
+      .optional()
+      .describe("Whether to return the result by value (default true)"),
+  },
+  async ({ processId, expression, targetId, returnByValue }) => {
+    try {
+      const proc = requireRunningProcess(processId);
+      await updateCDPTargets(proc);
+      const target = pickPageTarget(proc, targetId);
+      const result = await executeCDPCommand(
+        proc,
+        target.id,
+        "Runtime.evaluate",
+        {
+          expression,
+          returnByValue: returnByValue ?? true,
+          awaitPromise: true,
+        }
+      );
+      return textResult({ processId, targetId: target.id, result });
+    } catch (err) {
+      return textResult(
+        err instanceof Error ? err.message : String(err),
+        true
+      );
+    }
+  }
+);
+
+server.tool(
+  "reload",
+  "Reload a page target (or all page targets) in an Electron app",
+  {
+    processId: z.string().describe("Process id returned by start_app"),
+    targetId: z
+      .string()
+      .optional()
+      .describe("Optional CDP target id; omit to reload all page targets"),
+    ignoreCache: z
+      .boolean()
+      .optional()
+      .describe("If true, reload ignoring cache"),
+  },
+  async ({ processId, targetId, ignoreCache }) => {
+    try {
+      const proc = requireRunningProcess(processId);
+      await updateCDPTargets(proc);
+
+      const targets = targetId
+        ? [pickPageTarget(proc, targetId)]
+        : (proc.targets ?? []).filter(
+            (t) => t.type === "page" || Boolean(t.webSocketDebuggerUrl)
+          );
+
+      if (!targets.length) {
+        return textResult("No reloadable targets found", true);
+      }
+
+      const results = [];
+      for (const target of targets) {
+        const result = await executeCDPCommand(proc, target.id, "Page.reload", {
+          ignoreCache: ignoreCache ?? false,
+        });
+        results.push({ targetId: target.id, result });
+      }
+
+      return textResult({ processId, reloaded: results });
+    } catch (err) {
+      return textResult(
+        err instanceof Error ? err.message : String(err),
+        true
+      );
+    }
+  }
+);
+
+server.tool(
+  "pause",
+  "Pause JavaScript execution on a target via Debugger.pause",
+  {
+    processId: z.string().describe("Process id returned by start_app"),
+    targetId: z
+      .string()
+      .optional()
+      .describe("Optional CDP target id; defaults to the first page target"),
+  },
+  async ({ processId, targetId }) => {
+    try {
+      const proc = requireRunningProcess(processId);
+      await updateCDPTargets(proc);
+      const target = pickPageTarget(proc, targetId);
+      await connectToCDPTarget(proc, target.id);
+      await executeCDPCommand(proc, target.id, "Debugger.enable", {});
+      const result = await executeCDPCommand(
+        proc,
+        target.id,
+        "Debugger.pause",
+        {}
+      );
+      return textResult({ processId, targetId: target.id, result });
+    } catch (err) {
+      return textResult(
+        err instanceof Error ? err.message : String(err),
+        true
+      );
+    }
+  }
+);
+
+server.tool(
+  "resume",
+  "Resume JavaScript execution on a target via Debugger.resume",
+  {
+    processId: z.string().describe("Process id returned by start_app"),
+    targetId: z
+      .string()
+      .optional()
+      .describe("Optional CDP target id; defaults to the first page target"),
+  },
+  async ({ processId, targetId }) => {
+    try {
+      const proc = requireRunningProcess(processId);
+      await updateCDPTargets(proc);
+      const target = pickPageTarget(proc, targetId);
+      await executeCDPCommand(proc, target.id, "Debugger.enable", {});
+      const result = await executeCDPCommand(
+        proc,
+        target.id,
+        "Debugger.resume",
+        {}
+      );
+      return textResult({ processId, targetId: target.id, result });
+    } catch (err) {
+      return textResult(
+        err instanceof Error ? err.message : String(err),
+        true
+      );
+    }
+  }
+);
+
+server.tool(
+  "cdp_command",
+  "Execute an arbitrary Chrome DevTools Protocol method on a target",
+  {
+    processId: z.string().describe("Process id returned by start_app"),
+    method: z
+      .string()
+      .describe('CDP method name, e.g. "Page.navigate" or "Runtime.evaluate"'),
+    targetId: z
+      .string()
+      .optional()
+      .describe("Optional CDP target id; defaults to the first page target"),
+    params: z
+      .record(z.unknown())
+      .optional()
+      .describe("Optional JSON object of CDP method parameters"),
+  },
+  async ({ processId, method, targetId, params }) => {
+    try {
+      if (!method.includes(".")) {
+        return textResult(
+          'CDP method must be in "Domain.method" form',
+          true
+        );
+      }
+      const proc = requireRunningProcess(processId);
+      await updateCDPTargets(proc);
+      const target = pickPageTarget(proc, targetId);
+      const result = await executeCDPCommand(
+        proc,
+        target.id,
+        method,
+        params ?? {}
+      );
+      return textResult({
+        processId,
+        targetId: target.id,
+        method,
+        result,
+      });
+    } catch (err) {
+      return textResult(
+        err instanceof Error ? err.message : String(err),
+        true
+      );
+    }
+  }
+);
+
+// --- Resources (read-only inspection) ---
+
+server.resource(
+  "info",
+  "electron://info",
+  {
+    description: "Overview of Electron apps managed by this server",
+    mimeType: "application/json",
+  },
+  async (uri) => ({
+    contents: [
+      {
+        uri: uri.href,
+        mimeType: "application/json",
+        text: JSON.stringify({ processes: listProcesses() }, null, 2),
+      },
+    ],
+  })
+);
+
+server.resource(
+  "targets",
+  "electron://targets",
+  {
+    description: "All CDP targets across running Electron processes",
+    mimeType: "application/json",
+  },
+  async (uri) => {
+    const allTargets: Array<{ processId: string; target: unknown }> = [];
+
+    for (const [id, proc] of getAllProcesses().entries()) {
+      if (proc.status !== "running" || !proc.debugPort) {
+        continue;
+      }
+      try {
+        await updateCDPTargets(proc);
+        for (const target of proc.targets ?? []) {
+          allTargets.push({ processId: id, target });
+        }
+      } catch (err) {
+        log.warn(`Could not update targets for ${id}:`, err);
+      }
+    }
+
     return {
       contents: [
         {
-          uri,
+          uri: uri.href,
+          mimeType: "application/json",
           text: JSON.stringify(allTargets, null, 2),
         },
       ],
     };
   }
-  
-  // Handle CDP commands
-  if (uri.startsWith(ELECTRON_RESOURCES.CDP)) {
-    const cdpMatch = uri.match(/^electron:\/\/cdp\/([^/]+)\/([^/]+)(?:\/(.*))?$/);
-    if (!cdpMatch) {
-      throw new Error(`Invalid CDP URI: ${uri}`);
-    }
-    
-    const processId = cdpMatch[1];
-    const targetId = cdpMatch[2];
-    const command = cdpMatch[3]; // Optional command path
-    
-    const process = electronProcesses.get(processId);
-    if (!process || process.status !== 'running') {
-      throw new Error(`Process ${processId} not found or not running`);
-    }
-    
-    if (!command) {
-      // Just return information about the target
-      const target = process.targets?.find(t => t.id === targetId);
-      if (!target) {
-        throw new Error(`Target ${targetId} not found in process ${processId}`);
-      }
-      
-      return {
-        contents: [
-          {
-            uri,
-            text: JSON.stringify({
-              target,
-              availableDomains: [
-                'Page', 'Runtime', 'Debugger', 'DOM', 'Network', 'Console',
-                'Memory', 'Profiler', 'Performance', 'HeapProfiler'
-              ],
-              usage: `To execute a CDP command, append /{domain}/{command} to this URI`
-            }, null, 2),
-          },
-        ],
-      };
-    }
-    
-    // Parse the command path
-    const commandParts = command.split('/');
-    if (commandParts.length !== 2) {
-      throw new Error(`Invalid CDP command format: ${command}. Expected format: {domain}/{command}`);
-    }
-    
-    const domain = commandParts[0];
-    const method = commandParts[1];
-    
-    try {
-      // Execute the CDP command
-      const result = await executeCDPCommand(process, targetId, domain, method);
-      
-      return {
-        contents: [
-          {
-            uri,
-            text: JSON.stringify(result, null, 2),
-          },
-        ],
-      };
-    } catch (error) {
-      throw new Error(`Error executing CDP command: ${error instanceof Error ? error.message : String(error)}`);
-    }
-  }
-  
-  // Handle general Electron info resource
-  if (uri === ELECTRON_RESOURCES.INFO) {
-    return {
-      contents: [
-        {
-          uri,
-          text: JSON.stringify({
-            activeProcesses: Array.from(electronProcesses.entries()).map(([id, proc]) => ({
-              id,
-              name: proc.name,
-              status: proc.status,
-              pid: proc.pid,
-              startTime: proc.startTime
-            }))
-          }, null, 2),
-        },
-      ],
-    };
-  }
-  
-  // Handle process-specific resources
-  const processMatch = uri.match(/^electron:\/\/process\/(.+)$/);
-  if (processMatch) {
-    const processId = processMatch[1];
+);
+
+server.resource(
+  "process",
+  new ResourceTemplate("electron://process/{id}", {
+    list: async () => ({
+      resources: listProcesses().map((proc) => ({
+        uri: `electron://process/${proc.id}`,
+        name: `Electron Process: ${proc.name}`,
+        description: `Debug information for ${proc.name} (${proc.status})`,
+        mimeType: "application/json",
+      })),
+    }),
+  }),
+  {
+    description: "Detailed debug info for a managed Electron process",
+    mimeType: "application/json",
+  },
+  async (uri, { id }) => {
+    const processId = String(id);
     const debugInfo = await getElectronDebugInfo(processId);
-    
     if (!debugInfo) {
-      throw new Error(`Process ${processId} not found or not running`);
+      throw new Error(`Process not found: ${processId}`);
     }
-    
     return {
       contents: [
         {
-          uri,
+          uri: uri.href,
+          mimeType: "application/json",
           text: JSON.stringify(debugInfo, null, 2),
         },
       ],
     };
   }
-  
-  // Handle logs resources
-  const logsMatch = uri.match(/^electron:\/\/logs\/(.+)$/);
-  if (logsMatch) {
-    const processId = logsMatch[1];
-    const process = electronProcesses.get(processId);
-    
-    if (!process) {
-      throw new Error(`Process ${processId} not found`);
+);
+
+server.resource(
+  "logs",
+  new ResourceTemplate("electron://logs/{id}", {
+    list: async () => ({
+      resources: listProcesses().map((proc) => ({
+        uri: `electron://logs/${proc.id}`,
+        name: `Electron Logs: ${proc.name}`,
+        description: `Captured logs for ${proc.name}`,
+        mimeType: "text/plain",
+      })),
+    }),
+  }),
+  {
+    description: "Captured logs for a managed Electron process",
+    mimeType: "text/plain",
+  },
+  async (uri, { id }) => {
+    const processId = String(id);
+    const proc = getProcess(processId);
+    if (!proc) {
+      throw new Error(`Process not found: ${processId}`);
     }
-    
     return {
       contents: [
         {
-          uri,
-          text: process.logs.join('\n'),
+          uri: uri.href,
+          mimeType: "text/plain",
+          text: proc.logs.join(""),
         },
       ],
     };
   }
-  
-  // Handle operation resources
-  if (uri.startsWith(ELECTRON_RESOURCES.OPERATION)) {
-    const operationMatch = uri.match(/^electron:\/\/operation\/([^/]+)(?:\/(.*))?$/);
-    if (!operationMatch) {
-      throw new Error(`Invalid operation URI: ${uri}`);
+);
+
+server.resource(
+  "cdp-target",
+  new ResourceTemplate("electron://cdp/{processId}/{targetId}", {
+    list: async () => {
+      const resources = [];
+      for (const [processId, proc] of getAllProcesses().entries()) {
+        for (const target of proc.targets ?? []) {
+          resources.push({
+            uri: `electron://cdp/${processId}/${target.id}`,
+            name: `CDP: ${target.title || target.url || target.id}`,
+            description: `CDP target info for ${target.id}`,
+            mimeType: "application/json",
+          });
+        }
+      }
+      return { resources };
+    },
+  }),
+  {
+    description: "Read-only CDP target metadata",
+    mimeType: "application/json",
+  },
+  async (uri, { processId, targetId }) => {
+    const proc = getProcess(String(processId));
+    if (!proc) {
+      throw new Error(`Process not found: ${processId}`);
     }
-    
-    const operation = operationMatch[1];
-    let result: any;
-    
-    // Handle different operation types
-    if (operation === ELECTRON_OPERATIONS.START) {
-      // For the read request, just return instructions on how to use this resource
-      result = {
-        instructions: "To start an Electron app, send a POST request with JSON body: { \"appPath\": \"/path/to/electron/app\", \"debugPort\": 9222 }",
-        example: {
-          appPath: "C:\\path\\to\\electron\\app",
-          debugPort: 9222 // optional
-        }
-      };
-    } else if (operation === ELECTRON_OPERATIONS.STOP) {
-      // For the read request, just return instructions on how to use this resource
-      result = {
-        instructions: "To stop an Electron app, send a POST request with JSON body: { \"processId\": \"electron-12345678\" }",
-        example: {
-          processId: "electron-12345678"
-        }
-      };
-    } else if (operation === ELECTRON_OPERATIONS.RELOAD) {
-      // For the read request, just return instructions on how to use this resource
-      result = {
-        instructions: "To reload an Electron app, send a POST request with JSON body: { \"processId\": \"electron-12345678\", \"targetId\": \"page-123\" }",
-        example: {
-          processId: "electron-12345678",
-          targetId: "page-123" // Optional, if not provided will reload all targets
-        }
-      };
-    } else if (operation === ELECTRON_OPERATIONS.EVALUATE) {
-      // For the read request, just return instructions on how to use this resource
-      result = {
-        instructions: "To evaluate JavaScript in an Electron app, send a POST request with JSON body: { \"processId\": \"electron-12345678\", \"targetId\": \"page-123\", \"expression\": \"document.title\" }",
-        example: {
-          processId: "electron-12345678",
-          targetId: "page-123",
-          expression: "document.title",
-          returnByValue: true // Optional, whether to return the result by value
-        }
-      };
-    } else if (operation === ELECTRON_OPERATIONS.LIST) {
-      // For the list operation, we can return the actual list of processes
-      const processes = Array.from(electronProcesses.entries()).map(([id, proc]) => ({
-        id,
-        name: proc.name,
-        status: proc.status,
-        pid: proc.pid,
-        startTime: proc.startTime,
-        appPath: proc.appPath,
-        debugPort: proc.debugPort
-      }));
-      
-      result = {
-        processes
-      };
-    } else {
-      throw new Error(`Unknown operation: ${operation}`);
+    if (proc.status === "running" && proc.debugPort) {
+      try {
+        await updateCDPTargets(proc);
+      } catch (err) {
+        log.warn(`Could not refresh targets for ${processId}:`, err);
+      }
     }
-    
+    const target = proc.targets?.find((t) => t.id === String(targetId));
+    if (!target) {
+      throw new Error(`Target ${targetId} not found in process ${processId}`);
+    }
     return {
       contents: [
         {
-          uri,
-          text: JSON.stringify(result, null, 2)
-        }
-      ]
+          uri: uri.href,
+          mimeType: "application/json",
+          text: JSON.stringify(
+            {
+              processId,
+              target,
+              hint: "Use the evaluate, reload, pause, resume, or cdp_command tools to act on this target",
+            },
+            null,
+            2
+          ),
+        },
+      ],
     };
   }
-  
-  throw new Error(`Resource not found: ${uri}`);
-});
+);
 
-// Start server using stdio transport
 const transport = new StdioServerTransport();
 await server.connect(transport);
-console.info('{"jsonrpc": "2.0", "method": "log", "params": { "message": "Electron Debug MCP Server running..." }}');
+log.info("Electron Debug MCP Server running on stdio");

--- a/src/log.ts
+++ b/src/log.ts
@@ -1,0 +1,15 @@
+/**
+ * MCP stdio transport requires stdout to be JSON-RPC only.
+ * All diagnostic output must go to stderr.
+ */
+export const log = {
+  info(message: string, ...args: unknown[]): void {
+    console.error(`[electron-mcp] ${message}`, ...args);
+  },
+  warn(message: string, ...args: unknown[]): void {
+    console.error(`[electron-mcp:warn] ${message}`, ...args);
+  },
+  error(message: string, ...args: unknown[]): void {
+    console.error(`[electron-mcp:error] ${message}`, ...args);
+  },
+};

--- a/src/process-manager.ts
+++ b/src/process-manager.ts
@@ -150,7 +150,8 @@ export function getAllProcesses(): Map<string, ElectronProcess> {
 
 export async function startElectronApp(
   appPath: string,
-  debugPort?: number
+  debugPort?: number,
+  extraArgs: string[] = []
 ): Promise<ElectronProcess> {
   const resolvedAppPath = path.resolve(appPath);
   if (!fs.existsSync(resolvedAppPath)) {
@@ -161,9 +162,22 @@ export async function startElectronApp(
   const port =
     debugPort ?? Math.floor(Math.random() * (9999 - 9222 + 1)) + 9222;
 
+  // Containers / CI often need --no-sandbox for Electron to start.
+  const autoArgs: string[] = [];
+  if (
+    process.env.ELECTRON_MCP_NO_SANDBOX === "1" ||
+    process.env.CI === "true" ||
+    !process.env.DISPLAY
+  ) {
+    autoArgs.push("--no-sandbox");
+  }
+
   const args = [
     `--remote-debugging-port=${port}`,
     "--enable-logging",
+    "--disable-gpu",
+    ...autoArgs,
+    ...extraArgs,
     resolvedAppPath,
   ];
 

--- a/src/process-manager.ts
+++ b/src/process-manager.ts
@@ -1,0 +1,404 @@
+import { spawn, ChildProcess } from "child_process";
+import { createRequire } from "module";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+import { fileURLToPath } from "url";
+import CDP from "chrome-remote-interface";
+import { log } from "./log.js";
+
+const require = createRequire(import.meta.url);
+
+export interface CDPTarget {
+  id: string;
+  type: string;
+  title: string;
+  url: string;
+  webSocketDebuggerUrl?: string;
+  devtoolsFrontendUrl?: string;
+}
+
+export interface ElectronProcess {
+  id: string;
+  process: ChildProcess;
+  name: string;
+  status: "running" | "stopped" | "crashed";
+  pid?: number;
+  debugPort?: number;
+  startTime: Date;
+  logs: string[];
+  appPath: string;
+  cdpClient?: CDP.Client;
+  cdpTargetId?: string;
+  targets?: CDPTarget[];
+  lastTargetUpdate?: Date;
+}
+
+export interface ElectronDebugInfo {
+  id: string;
+  name: string;
+  status: ElectronProcess["status"];
+  pid?: number;
+  debugPort?: number;
+  startTime: Date;
+  appPath: string;
+  webContents: Array<{
+    id: number;
+    url: string;
+    title: string;
+    type: string;
+    debuggable: boolean;
+    debugPort?: number;
+    targetId?: string;
+  }>;
+}
+
+const electronProcesses = new Map<string, ElectronProcess>();
+
+function getElectronExecutablePath(): string {
+  try {
+    const fromPackage = require("electron") as string;
+    if (fromPackage && fs.existsSync(fromPackage)) {
+      return fromPackage;
+    }
+  } catch {
+    // Fall through to path search
+  }
+
+  const isWin = process.platform === "win32";
+  const binName = isWin ? "electron.cmd" : "electron";
+  const here = path.dirname(fileURLToPath(import.meta.url));
+
+  const candidates = [
+    path.resolve(process.cwd(), "node_modules", ".bin", binName),
+    path.resolve(here, "..", "node_modules", ".bin", binName),
+  ];
+
+  if (isWin) {
+    candidates.push(
+      path.join(os.homedir(), "AppData", "Roaming", "npm", binName)
+    );
+  } else {
+    candidates.push(path.join(os.homedir(), ".npm-global", "bin", binName));
+  }
+
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate)) {
+      return candidate;
+    }
+  }
+
+  return "electron";
+}
+
+async function waitForDebugPort(
+  port: number,
+  timeoutMs = 20000
+): Promise<void> {
+  const started = Date.now();
+  let lastError: unknown;
+
+  while (Date.now() - started < timeoutMs) {
+    try {
+      const response = await fetch(`http://127.0.0.1:${port}/json/version`);
+      if (response.ok) {
+        return;
+      }
+      lastError = new Error(`HTTP ${response.status}`);
+    } catch (err) {
+      lastError = err;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+
+  throw new Error(
+    `Debug port ${port} did not become ready within ${timeoutMs}ms: ${
+      lastError instanceof Error ? lastError.message : String(lastError)
+    }`
+  );
+}
+
+export function listProcesses(): Array<{
+  id: string;
+  name: string;
+  status: ElectronProcess["status"];
+  pid?: number;
+  debugPort?: number;
+  startTime: Date;
+  appPath: string;
+  targetCount: number;
+}> {
+  return Array.from(electronProcesses.entries()).map(([id, proc]) => ({
+    id,
+    name: proc.name,
+    status: proc.status,
+    pid: proc.pid,
+    debugPort: proc.debugPort,
+    startTime: proc.startTime,
+    appPath: proc.appPath,
+    targetCount: proc.targets?.length ?? 0,
+  }));
+}
+
+export function getProcess(id: string): ElectronProcess | undefined {
+  return electronProcesses.get(id);
+}
+
+export function getAllProcesses(): Map<string, ElectronProcess> {
+  return electronProcesses;
+}
+
+export async function startElectronApp(
+  appPath: string,
+  debugPort?: number
+): Promise<ElectronProcess> {
+  const resolvedAppPath = path.resolve(appPath);
+  if (!fs.existsSync(resolvedAppPath)) {
+    throw new Error(`App path does not exist: ${resolvedAppPath}`);
+  }
+
+  const id = `electron-${Date.now()}`;
+  const port =
+    debugPort ?? Math.floor(Math.random() * (9999 - 9222 + 1)) + 9222;
+
+  const args = [
+    `--remote-debugging-port=${port}`,
+    "--enable-logging",
+    resolvedAppPath,
+  ];
+
+  const electronPath = getElectronExecutablePath();
+  log.info(`Starting ${resolvedAppPath} via ${electronPath} on port ${port}`);
+
+  const electronProc = spawn(electronPath, args, {
+    stdio: ["ignore", "pipe", "pipe"],
+    env: { ...process.env, ELECTRON_ENABLE_LOGGING: "1" },
+    shell: process.platform === "win32" && electronPath.endsWith(".cmd"),
+  });
+
+  const electronProcess: ElectronProcess = {
+    id,
+    process: electronProc,
+    name: path.basename(resolvedAppPath),
+    status: "running",
+    pid: electronProc.pid,
+    debugPort: port,
+    startTime: new Date(),
+    logs: [],
+    appPath: resolvedAppPath,
+  };
+
+  const appendLog = (chunk: Buffer, stream: "stdout" | "stderr") => {
+    const text = chunk.toString();
+    electronProcess.logs.push(text);
+    // Cap in-memory logs to avoid unbounded growth
+    if (electronProcess.logs.length > 2000) {
+      electronProcess.logs.splice(0, electronProcess.logs.length - 2000);
+    }
+    log.info(`[${id}:${stream}] ${text.trimEnd()}`);
+  };
+
+  electronProc.stdout?.on("data", (data: Buffer) => appendLog(data, "stdout"));
+  electronProc.stderr?.on("data", (data: Buffer) => appendLog(data, "stderr"));
+
+  electronProc.on("error", (err) => {
+    electronProcess.status = "crashed";
+    log.error(`[${id}] Failed to start:`, err);
+  });
+
+  electronProc.on("exit", (code) => {
+    electronProcess.status = code === 0 ? "stopped" : "crashed";
+    log.info(`[${id}] Process exited with code ${code}`);
+    void closeCdpClient(electronProcess);
+  });
+
+  electronProcesses.set(id, electronProcess);
+
+  try {
+    await waitForDebugPort(port);
+    await updateCDPTargets(electronProcess);
+  } catch (err) {
+    log.warn(`[${id}] App started but CDP is not ready yet:`, err);
+  }
+
+  return electronProcess;
+}
+
+async function closeCdpClient(electronProcess: ElectronProcess): Promise<void> {
+  if (!electronProcess.cdpClient) {
+    return;
+  }
+  try {
+    await electronProcess.cdpClient.close();
+  } catch (err) {
+    log.error(`[${electronProcess.id}] Error closing CDP client:`, err);
+  }
+  electronProcess.cdpClient = undefined;
+  electronProcess.cdpTargetId = undefined;
+}
+
+export async function stopElectronApp(id: string): Promise<boolean> {
+  const electronProcess = electronProcesses.get(id);
+  if (!electronProcess) {
+    return false;
+  }
+
+  await closeCdpClient(electronProcess);
+
+  if (electronProcess.status === "running") {
+    electronProcess.process.kill();
+    // Give it a moment, then force-kill if needed
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    if (
+      electronProcess.status === "running" &&
+      electronProcess.pid &&
+      !electronProcess.process.killed
+    ) {
+      try {
+        electronProcess.process.kill("SIGKILL");
+      } catch {
+        // Process may already be gone
+      }
+    }
+  }
+
+  electronProcess.status = "stopped";
+  return true;
+}
+
+export async function updateCDPTargets(
+  electronProcess: ElectronProcess
+): Promise<CDPTarget[]> {
+  if (!electronProcess.debugPort) {
+    throw new Error("No debug port available for this Electron process");
+  }
+
+  const response = await fetch(
+    `http://127.0.0.1:${electronProcess.debugPort}/json/list`
+  );
+  if (!response.ok) {
+    throw new Error(`Failed to get targets: ${response.statusText}`);
+  }
+
+  const targets = (await response.json()) as CDPTarget[];
+  electronProcess.targets = targets;
+  electronProcess.lastTargetUpdate = new Date();
+  return targets;
+}
+
+export async function connectToCDPTarget(
+  electronProcess: ElectronProcess,
+  targetId: string
+): Promise<CDP.Client> {
+  if (!electronProcess.debugPort) {
+    throw new Error("No debug port available for this Electron process");
+  }
+
+  const stale =
+    !electronProcess.targets ||
+    !electronProcess.lastTargetUpdate ||
+    Date.now() - electronProcess.lastTargetUpdate.getTime() > 5000;
+
+  if (stale) {
+    await updateCDPTargets(electronProcess);
+  }
+
+  const target = electronProcess.targets?.find((t) => t.id === targetId);
+  if (!target) {
+    throw new Error(`Target ${targetId} not found`);
+  }
+
+  if (
+    electronProcess.cdpClient &&
+    electronProcess.cdpTargetId === targetId
+  ) {
+    return electronProcess.cdpClient;
+  }
+
+  await closeCdpClient(electronProcess);
+
+  const client = await CDP({
+    target: targetId,
+    port: electronProcess.debugPort,
+    host: "127.0.0.1",
+  });
+
+  electronProcess.cdpClient = client;
+  electronProcess.cdpTargetId = targetId;
+  return client;
+}
+
+export async function executeCDPCommand(
+  electronProcess: ElectronProcess,
+  targetId: string,
+  method: string,
+  params: Record<string, unknown> = {}
+): Promise<unknown> {
+  const client = await connectToCDPTarget(electronProcess, targetId);
+  return client.send(method, params);
+}
+
+export async function getElectronDebugInfo(
+  id: string
+): Promise<ElectronDebugInfo | null> {
+  const electronProcess = electronProcesses.get(id);
+  if (!electronProcess) {
+    return null;
+  }
+
+  if (electronProcess.status === "running" && electronProcess.debugPort) {
+    try {
+      await updateCDPTargets(electronProcess);
+    } catch (err) {
+      log.warn(`[${id}] Could not update CDP targets:`, err);
+    }
+  }
+
+  const webContents =
+    electronProcess.targets?.map((target, index) => ({
+      id: index + 1,
+      url: target.url,
+      title: target.title,
+      type: target.type,
+      debuggable: Boolean(target.webSocketDebuggerUrl),
+      debugPort: electronProcess.debugPort,
+      targetId: target.id,
+    })) ?? [];
+
+  return {
+    id: electronProcess.id,
+    name: electronProcess.name,
+    status: electronProcess.status,
+    pid: electronProcess.pid,
+    debugPort: electronProcess.debugPort,
+    startTime: electronProcess.startTime,
+    appPath: electronProcess.appPath,
+    webContents,
+  };
+}
+
+export function pickPageTarget(
+  electronProcess: ElectronProcess,
+  targetId?: string
+): CDPTarget {
+  if (!electronProcess.targets?.length) {
+    throw new Error(
+      `No CDP targets available for process ${electronProcess.id}`
+    );
+  }
+
+  if (targetId) {
+    const match = electronProcess.targets.find((t) => t.id === targetId);
+    if (!match) {
+      throw new Error(`Target ${targetId} not found`);
+    }
+    return match;
+  }
+
+  const page =
+    electronProcess.targets.find((t) => t.type === "page") ??
+    electronProcess.targets.find((t) => Boolean(t.webSocketDebuggerUrl)) ??
+    electronProcess.targets[0];
+
+  return page;
+}

--- a/src/types/chrome-remote-interface.d.ts
+++ b/src/types/chrome-remote-interface.d.ts
@@ -1,4 +1,4 @@
-declare module 'chrome-remote-interface' {
+declare module "chrome-remote-interface" {
   interface CDPOptions {
     host?: string;
     port?: number;
@@ -11,21 +11,24 @@ declare module 'chrome-remote-interface' {
   }
 
   interface CDPClient {
-    send(method: string, params?: object): Promise<any>;
-    on(event: string, callback: (params: any) => void): void;
-    close(): void;
+    send(method: string, params?: object): Promise<unknown>;
+    on(event: string, callback: (params: unknown) => void): void;
+    close(): Promise<void> | void;
   }
 
-  function CDP(options?: CDPOptions): Promise<CDPClient>;
-  
   namespace CDP {
-    function List(options?: Omit<CDPOptions, 'target'>): Promise<any[]>;
-    function New(options?: Omit<CDPOptions, 'target'>): Promise<{ webSocketDebuggerUrl: string }>;
+    type Client = CDPClient;
+    function List(options?: Omit<CDPOptions, "target">): Promise<unknown[]>;
+    function New(
+      options?: Omit<CDPOptions, "target">
+    ): Promise<{ webSocketDebuggerUrl: string }>;
     function Activate(options?: CDPOptions): Promise<void>;
     function Close(options?: CDPOptions): Promise<void>;
-    function Version(options?: Omit<CDPOptions, 'target'>): Promise<any>;
-    function Protocol(options?: Omit<CDPOptions, 'target'>): Promise<any>;
+    function Version(options?: Omit<CDPOptions, "target">): Promise<unknown>;
+    function Protocol(options?: Omit<CDPOptions, "target">): Promise<unknown>;
   }
+
+  function CDP(options?: CDPOptions): Promise<CDP.Client>;
 
   export = CDP;
 }

--- a/test/mcp-smoke.mjs
+++ b/test/mcp-smoke.mjs
@@ -1,0 +1,266 @@
+#!/usr/bin/env node
+/**
+ * End-to-end smoke test for the Electron Debug MCP server.
+ * Spawns the server over stdio, drives tools against fixtures/minimal-electron-app.
+ */
+import { spawn } from "child_process";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, "..");
+const serverEntry = path.join(root, "build", "index.js");
+const fixtureApp = path.join(root, "fixtures", "minimal-electron-app");
+const DEBUG_PORT = 9339;
+
+class McpClient {
+  constructor(command, args, env = {}) {
+    this.child = spawn(command, args, {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, ...env },
+      cwd: root,
+    });
+    this.buffer = "";
+    this.pending = new Map();
+    this.nextId = 1;
+    this.stderr = "";
+
+    this.child.stdout.setEncoding("utf8");
+    this.child.stdout.on("data", (chunk) => this.#onStdout(chunk));
+    this.child.stderr.setEncoding("utf8");
+    this.child.stderr.on("data", (chunk) => {
+      this.stderr += chunk;
+    });
+    this.child.on("exit", (code, signal) => {
+      for (const [, { reject }] of this.pending) {
+        reject(
+          new Error(`MCP server exited (code=${code}, signal=${signal})`)
+        );
+      }
+      this.pending.clear();
+    });
+  }
+
+  #onStdout(chunk) {
+    this.buffer += chunk;
+    let idx;
+    while ((idx = this.buffer.indexOf("\n")) !== -1) {
+      const line = this.buffer.slice(0, idx).trim();
+      this.buffer = this.buffer.slice(idx + 1);
+      if (!line) continue;
+      let msg;
+      try {
+        msg = JSON.parse(line);
+      } catch {
+        continue;
+      }
+      if (msg.id != null && this.pending.has(msg.id)) {
+        const { resolve, reject } = this.pending.get(msg.id);
+        this.pending.delete(msg.id);
+        if (msg.error) {
+          reject(new Error(JSON.stringify(msg.error)));
+        } else {
+          resolve(msg.result);
+        }
+      }
+    }
+  }
+
+  request(method, params = {}) {
+    const id = this.nextId++;
+    const payload = { jsonrpc: "2.0", id, method, params };
+    return new Promise((resolve, reject) => {
+      this.pending.set(id, { resolve, reject });
+      this.child.stdin.write(JSON.stringify(payload) + "\n");
+    });
+  }
+
+  notify(method, params = {}) {
+    this.child.stdin.write(
+      JSON.stringify({ jsonrpc: "2.0", method, params }) + "\n"
+    );
+  }
+
+  async close() {
+    try {
+      this.child.stdin.end();
+    } catch {
+      // ignore
+    }
+    if (!this.child.killed) {
+      this.child.kill("SIGTERM");
+    }
+    await new Promise((resolve) => {
+      if (this.child.exitCode != null) return resolve();
+      this.child.once("exit", resolve);
+      setTimeout(() => {
+        this.child.kill("SIGKILL");
+        resolve();
+      }, 2000);
+    });
+  }
+}
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+function parseToolText(result) {
+  assert(result?.content?.[0]?.type === "text", "tool result missing text");
+  const text = result.content[0].text;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+async function main() {
+  const steps = [];
+  const pass = (name) => {
+    steps.push(`PASS ${name}`);
+    console.log(`PASS ${name}`);
+  };
+  const fail = (name, err) => {
+    steps.push(`FAIL ${name}: ${err}`);
+    console.error(`FAIL ${name}: ${err}`);
+  };
+
+  const client = new McpClient("node", [serverEntry], {
+    ELECTRON_MCP_NO_SANDBOX: "1",
+  });
+
+  let processId;
+
+  try {
+    const init = await client.request("initialize", {
+      protocolVersion: "2024-11-05",
+      capabilities: {},
+      clientInfo: { name: "mcp-smoke-test", version: "1.0.0" },
+    });
+    assert(init?.serverInfo?.name === "electron-debug-mcp", "bad serverInfo");
+    assert(init?.capabilities?.tools, "tools capability missing");
+    client.notify("notifications/initialized");
+    pass("initialize");
+
+    const tools = await client.request("tools/list");
+    const names = new Set((tools.tools ?? []).map((t) => t.name));
+    for (const required of [
+      "start_app",
+      "stop_app",
+      "list_apps",
+      "evaluate",
+      "list_targets",
+      "cdp_command",
+    ]) {
+      assert(names.has(required), `missing tool ${required}`);
+    }
+    pass("tools/list");
+
+    const resources = await client.request("resources/list");
+    assert(
+      (resources.resources ?? []).some((r) => r.uri === "electron://info"),
+      "electron://info resource missing"
+    );
+    pass("resources/list");
+
+    const startResult = await client.request("tools/call", {
+      name: "start_app",
+      arguments: {
+        appPath: fixtureApp,
+        debugPort: DEBUG_PORT,
+        extraArgs: ["--no-sandbox"],
+      },
+    });
+    assert(!startResult.isError, `start_app error: ${startResult.content?.[0]?.text}`);
+    const started = parseToolText(startResult);
+    processId = started.id;
+    assert(processId, "start_app did not return process id");
+    assert(started.debugPort === DEBUG_PORT, "debug port mismatch");
+    pass(`start_app (${processId})`);
+
+    // Give the page a moment to finish loading after CDP port is up.
+    await new Promise((r) => setTimeout(r, 1500));
+
+    const targetsResult = await client.request("tools/call", {
+      name: "list_targets",
+      arguments: { processId },
+    });
+    assert(!targetsResult.isError, `list_targets error: ${targetsResult.content?.[0]?.text}`);
+    const targets = parseToolText(targetsResult);
+    assert(
+      Array.isArray(targets.targets) && targets.targets.length > 0,
+      "expected at least one CDP target"
+    );
+    pass(`list_targets (${targets.targets.length})`);
+
+    const evalResult = await client.request("tools/call", {
+      name: "evaluate",
+      arguments: {
+        processId,
+        expression: "document.title + '|' + (window.__FIXTURE__?.name || '')",
+      },
+    });
+    assert(!evalResult.isError, `evaluate error: ${evalResult.content?.[0]?.text}`);
+    const evaluated = parseToolText(evalResult);
+    const value = evaluated?.result?.result?.value;
+    assert(
+      typeof value === "string" &&
+        value.includes("Minimal Electron Fixture") &&
+        value.includes("minimal-electron-app"),
+      `unexpected evaluate value: ${JSON.stringify(value)}`
+    );
+    pass(`evaluate (${value})`);
+
+    const listResult = await client.request("tools/call", {
+      name: "list_apps",
+      arguments: {},
+    });
+    const listed = parseToolText(listResult);
+    assert(
+      (listed.processes ?? []).some((p) => p.id === processId),
+      "list_apps missing started process"
+    );
+    pass("list_apps");
+
+    const info = await client.request("resources/read", {
+      uri: "electron://info",
+    });
+    assert(info?.contents?.[0]?.text?.includes(processId), "info resource missing process");
+    pass("resources/read electron://info");
+
+    const stopResult = await client.request("tools/call", {
+      name: "stop_app",
+      arguments: { processId },
+    });
+    assert(!stopResult.isError, `stop_app error: ${stopResult.content?.[0]?.text}`);
+    pass("stop_app");
+    processId = undefined;
+
+    console.log("\nAll smoke tests passed.");
+    await client.close();
+    process.exit(0);
+  } catch (err) {
+    fail("smoke", err instanceof Error ? err.message : String(err));
+    if (client.stderr) {
+      console.error("\n--- server stderr (tail) ---");
+      console.error(client.stderr.slice(-2000));
+    }
+    if (processId) {
+      try {
+        await client.request("tools/call", {
+          name: "stop_app",
+          arguments: { processId },
+        });
+      } catch {
+        // best effort
+      }
+    }
+    await client.close();
+    process.exit(1);
+  }
+}
+
+main();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
The previous server advertised start/stop/evaluate as MCP **resources** that only returned “send a POST” instructions, never actually launched apps, and logged to stdout (breaking stdio MCP).

This PR makes it a working MCP server:

- **Tools**: `start_app`, `stop_app`, `list_apps`, `get_logs`, `list_targets`, `evaluate`, `reload`, `pause`, `resume`, `cdp_command`
- **Resources**: read-only `electron://info`, `targets`, `process/{id}`, `logs/{id}`, `cdp/{processId}/{targetId}`
- **Logging**: all diagnostics go to **stderr**
- **Process mgmt**: cross-platform Electron binary resolution, wait for debug port, CDP helpers, `extraArgs` / `ELECTRON_MCP_NO_SANDBOX` for CI
- **Tests**: `fixtures/minimal-electron-app` + `npm test` (`test/mcp-smoke.mjs`) covering initialize → start → targets → evaluate → stop
- **Docs**: README updated for Cursor config at `D:/GH/electron-mcp-server`

## Test plan
- [x] `npm run build` succeeds
- [x] Smoke test: `initialize` + `tools/list` over stdio returns tools/resources capabilities
- [x] `npm test` passes end-to-end against the minimal Electron fixture
- [ ] Locally: point Cursor MCP at `node D:/GH/electron-mcp-server/build/index.js`, pull this branch, `start_app` against a real Electron app, then `evaluate` / `list_targets`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dcda3381-e2f1-4e79-845c-8c9d8a362599"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dcda3381-e2f1-4e79-845c-8c9d8a362599"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

