### PR TITLE
docs: README cleanup (logo.png, At a glance, Feature tour spacing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,6 @@
 </p>
 
 <p align="center">
-  <img src="assets/logo.png" alt="" width="72" height="72" />
-</p>
-
-<p align="center">
   <a href="#-60-second-quick-start"><img src="https://img.shields.io/badge/⚡_Quick_Start-0F766E?style=for-the-badge" alt="Quick Start" /></a>
   <a href="#-complete-tools-cheatsheet"><img src="https://img.shields.io/badge/🛠️_36_Tools-47848F?style=for-the-badge" alt="36 Tools" /></a>
   <a href="#-usage-examples"><img src="https://img.shields.io/badge/📚_Examples-0EA5E9?style=for-the-badge" alt="Examples" /></a>
@@ -74,7 +70,7 @@ It speaks **MCP over stdio** (Cursor / Claude Desktop friendly), bridges to **Ch
 
 ### 📊 At a glance
 
-| | |
+| Aspect | Details |
 | :--- | :--- |
 | 🔌 **Transport** | MCP **stdio** JSON-RPC |
 | 🧬 **Debug bridge** | Chrome DevTools Protocol (Runtime · Page · Network · Debugger · Input · Log · Tracing) |
@@ -151,6 +147,7 @@ Electron bugs are often **invisible** to coding agents:
 - ⏹️ `stop_app` — kill owned / detach attached
 - 📋 `list_apps` — sessions, ports, buffer counts
 - 🩺 `diagnose` — port health + recent errors
+
 </td>
 <td width="50%" valign="top">
 
@@ -164,6 +161,7 @@ Electron bugs are often **invisible** to coding agents:
 - 🌐 `get_network_log` — request/response/fail
 - 📜 `get_logs` — Electron stdout/stderr
 - 🎯 `list_targets` / `page_info`
+
 </td>
 </tr>
 <tr>
@@ -176,6 +174,7 @@ Electron bugs are often **invisible** to coding agents:
 - ⌨️ `type_text` (+ clear / Enter) · `press_key` (+ modifiers)
 - 🔄 `reload` · ⏸️ `pause` · ▶️ `resume`
 - 🧹 `clear_buffers`
+
 </td>
 <td width="50%" valign="top">
 
@@ -187,6 +186,7 @@ Electron bugs are often **invisible** to coding agents:
 - 📈 `start_tracing` / `stop_tracing`
 - 🛡️ stderr-only diagnostics (stdio-safe)
 - 🧰 `cdp_command` for any DevTools method
+
 </td>
 </tr>
 </table>
@@ -899,7 +899,7 @@ CI: [`.github/workflows/ci.yml`](./.github/workflows/ci.yml) (Ubuntu + Xvfb).
 
 ```text
 electron-mcp-server/
-├── assets/logo.svg · logo.png
+├── assets/logo.svg
 ├── examples/cursor-mcp.json
 ├── fixtures/minimal-electron-app/
 ├── scripts/ensure-electron.mjs · fix-electron.cmd · fix-electron.ps1


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Remove broken `assets/logo.png` image (file does not exist; keep `logo.svg`)
- Fix **At a glance** empty header row → `Aspect | Details`
- Restore bottom spacing inside **Feature tour** table cells

## Test plan

- [ ] Confirm GitHub README preview: no broken image, no empty header, Feature tour lists have bottom padding

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dcda3381-e2f1-4e79-845c-8c9d8a362599"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dcda3381-e2f1-4e79-845c-8c9d8a362599"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

